### PR TITLE
feat(useRover): Allow scroll to be locked on rover

### DIFF
--- a/cypress/test/unit/components/roving-tabindex/use-rover.spec.tsx
+++ b/cypress/test/unit/components/roving-tabindex/use-rover.spec.tsx
@@ -16,7 +16,10 @@ const TestButton: React.FC<{
 	id?: string;
 }> = ({ disabled, children, id }) => {
 	const ref = React.useRef(null);
-	const [tabIndex, focused, handleKeyDown, handleClick] = useRover(ref, disabled);
+	const [tabIndex, focused, handleKeyDown, handleClick] = useRover(ref, {
+		disabled,
+		lockScrollOnRover: true,
+	});
 	useFocus(ref, focused);
 	return (
 		<button

--- a/documentation/docs/manage-focus/demos/roving-tab-index.tsx
+++ b/documentation/docs/manage-focus/demos/roving-tab-index.tsx
@@ -13,7 +13,10 @@ const SidenavLink = ({
 	onClick,
 }: Pick<React.HTMLProps<HTMLButtonElement>, "disabled" | "children" | "onClick">) => {
 	const ref = useRef(null);
-	const [tabIndex, focused, handleKeyDown, handleClick] = useRover(ref, disabled);
+	const [tabIndex, focused, handleKeyDown, handleClick] = useRover(ref, {
+		disabled,
+		lockScrollOnRover: true,
+	});
 	useFocus(ref, focused);
 	return (
 		<button

--- a/documentation/docs/manage-focus/the-rover.mdx
+++ b/documentation/docs/manage-focus/the-rover.mdx
@@ -19,7 +19,7 @@ import { Subtitle, BrowserWindow, PropsTable } from "../../src/components/index"
 - Then, use the `ArrowUp` and `ArrowDown` keys to go through each option.
 - Try pressing `Home` or `End` to jump right to the first or last elements on the group.
 - Press `tab` (or `shift+tab`) again to exit.
-:::
+  :::
 
 ### Development Instructions
 
@@ -58,7 +58,7 @@ For each one of those, wrap them with your own component and use the `useRover` 
 const MenuButton = ({ disabled = false, children }) => {
 	const buttonRef = useRef(null);
 
-	const [tabIndex, focused, handleKeyDown, handleClick] = useRover(buttonRef, disabled);
+	const [tabIndex, focused, handleKeyDown, handleClick] = useRover(buttonRef, { disabled });
 
 	useFocus(focused, buttonRef);
 

--- a/src/components/roving-tabindex/index.ts
+++ b/src/components/roving-tabindex/index.ts
@@ -60,6 +60,12 @@ export interface IRovingAction<Action> {
 	type: Action;
 }
 
+export interface IuseRoverOptions {
+	disabled?: boolean;
+	id?: string;
+	lockScrollOnRover?: boolean;
+}
+
 export type RovingAction =
 	| IRovingActionWithPayload<"REGISTER", TabStop>
 	| IRovingActionWithPayload<"UNREGISTER", IRovingActionPayloadID>
@@ -77,7 +83,7 @@ export type RovingContext = {
 };
 
 export { Provider as RoverProvider } from "./rover-provider/provider";
-export { RoverConsumer } from "./rover-provider/consumer"
-export { RoverContext } from "./rover-provider/context"
+export { RoverConsumer } from "./rover-provider/consumer";
+export { RoverContext } from "./rover-provider/context";
 export * from "./use-rover";
 export * from "./use-focus-effect";


### PR DESCRIPTION
When navigating on a grouped set of elements with keyboard arrows, the browser's default behaviour is not prevented, causing a scroll position adjustment. Although that might be useful in some cases, in other scenarios it might do more harm than good.

With this pull request, the developer is allowed to choose which is the best behaviour for his scenario. Below you have the differences between the two behaviours.

**Note:**
- To avoid passing too many arguments to `useRover` hook, I'm proposing to provide an `options` object instead.

https://github.com/JoaoTMDias/react-a11y-tools/assets/35606973/99d5951f-334d-43f4-824a-9a4a4e6abf57


https://github.com/JoaoTMDias/react-a11y-tools/assets/35606973/18f4aad5-bcd6-4c85-a6bf-28879d69b5c2